### PR TITLE
데이터 복사시 잘못 복사되는 Bug 수정

### DIFF
--- a/data-structure/app/src/main/java/data/structure/array/MyPriorityQueue.java
+++ b/data-structure/app/src/main/java/data/structure/array/MyPriorityQueue.java
@@ -23,8 +23,8 @@ public class MyPriorityQueue<E extends Comparable> implements Queue<E> {
     private void add(E value) {
         this.arrResize();
         int index = findIndex(value);
-        for (int i = index + 1; this.arrLength > i; i++) {
-            this.arr[i + 1] = this.arr[i];
+        for (int i = this.arrLength; index < i; i--) {
+            this.arr[i] = this.arr[i - 1];
         }
         this.arr[index] = value;
     }

--- a/data-structure/app/src/main/java/data/structure/array/MyPriorityQueue.java
+++ b/data-structure/app/src/main/java/data/structure/array/MyPriorityQueue.java
@@ -56,7 +56,7 @@ public class MyPriorityQueue<E extends Comparable> implements Queue<E> {
 
     @Override
     public E peek() {
-        return (E) this.arr[this.arrSize - 1];
+        return (E) this.arr[this.arrLength - 1];
     }
 
     @Override

--- a/data-structure/app/src/test/java/data/structure/array/MyPriorityQueueTest.java
+++ b/data-structure/app/src/test/java/data/structure/array/MyPriorityQueueTest.java
@@ -87,4 +87,64 @@ class MyPriorityQueueTest {
         // then
         assert pq.size() == 0;
     }
+
+    @Test
+    @DisplayName("clear() 했다가 offer() 하면 size()가 1이 되어야 한다.")
+    void testClearOffer() {
+        // given
+        MyPriorityQueue<TestNode> pq = new MyPriorityQueue<>();
+        pq.offer(node1);
+        pq.offer(node2);
+        pq.offer(node3);
+        pq.clear();
+
+        // when
+        pq.offer(node1);
+
+        // then
+        assert pq.size() == 1;
+    }
+
+
+    @Test
+    @DisplayName("다수의 데이터를 넣어도 순서가 보장되는지 확인")
+    void testOfferPollMany() {
+        // given
+        MyPriorityQueue<TestNode> pq = new MyPriorityQueue<>();
+        pq.offer(new TestNode("테스트1", 1));
+        pq.offer(new TestNode("테스트2", 4));
+        pq.offer(new TestNode("테스트3", 7));
+        pq.offer(new TestNode("테스트4", 2));
+        pq.offer(new TestNode("테스트5", 3));
+        pq.offer(new TestNode("테스트6", 5));
+        pq.offer(new TestNode("테스트7", 1));
+        pq.offer(new TestNode("테스트8", 2));
+        pq.offer(new TestNode("테스트9", 3));
+        pq.offer(new TestNode("테스트10", 6));
+
+        // when
+        TestNode pollNode1 = pq.poll();
+        TestNode pollNode2 = pq.poll();
+        TestNode pollNode3 = pq.poll();
+        TestNode pollNode4 = pq.poll();
+        TestNode pollNode5 = pq.poll();
+        TestNode pollNode6 = pq.poll();
+        TestNode pollNode7 = pq.poll();
+        TestNode pollNode8 = pq.poll();
+        TestNode pollNode9 = pq.poll();
+        TestNode pollNode10 = pq.poll();
+
+        // then
+        assert pollNode1.getPriority() == 7;
+        assert pollNode2.getPriority() == 6;
+        assert pollNode3.getPriority() == 5;
+        assert pollNode4.getPriority() == 4;
+        assert pollNode5.getPriority() == 3;
+        assert pollNode6.getPriority() == 3;
+        assert pollNode7.getPriority() == 2;
+        assert pollNode8.getPriority() == 2;
+        assert pollNode9.getPriority() == 1;
+        assert pollNode10.getPriority() == 1;
+        assert pq.size() == 0;
+    }
 }

--- a/data-structure/app/src/test/java/data/structure/array/MyPriorityQueueTest.java
+++ b/data-structure/app/src/test/java/data/structure/array/MyPriorityQueueTest.java
@@ -56,6 +56,23 @@ class MyPriorityQueueTest {
     }
 
     @Test
+    @DisplayName("3개의 값을 Offer할 경우 가장 Priority가 높은 값이 Peek되어야 한다.")
+    void testOfferPeek() {
+        // given
+        MyPriorityQueue<TestNode> pq = new MyPriorityQueue<>();
+        pq.offer(node1);
+        pq.offer(node2);
+        pq.offer(node3);
+
+        // when
+        TestNode peekNode = pq.peek();
+
+        // then
+        assert peekNode.getBrandName().equals("LG");
+        assert pq.size() == 3;
+    }
+
+    @Test
     @DisplayName("clear() 메서드 실행시 size()가 0이 되어야 한다.")
     void testClear() {
         // given


### PR DESCRIPTION
## Related Issue

Related to : #4 

## Overview

- 데이터 앞 -> 뒤로 복사해서 동일 데이터가 복사되는 Bug 수정
- 순서 제대로 보장될 수 있게 수정
- peek() 함수 null 반환하던 Bug 수정 
- 다수의 노드 추가시 순서 제대로 보장되는지 Test Code 작성
