### PR TITLE
User 저장할 때 User Email로 다시 찾아와서 반환하는 로직 수정

### DIFF
--- a/mybatis-hexagonal-exam/src/main/java/org/rookedsysc/mybatishexagonalexam/adapter/out/AuthAdapter.java
+++ b/mybatis-hexagonal-exam/src/main/java/org/rookedsysc/mybatishexagonalexam/adapter/out/AuthAdapter.java
@@ -13,8 +13,8 @@ public class AuthAdapter implements SignUpPort {
 
     @Override
     public UserEntity signUp(UserEntity userEntity) {
-        userMapper.save(userEntity);
-        userEntity = userMapper.findByEmail(userEntity.getEmail());
+        Long id = userMapper.save(userEntity);
+        userEntity.setId(id);
         return userEntity;
     }
 }

--- a/mybatis-hexagonal-exam/src/main/java/org/rookedsysc/mybatishexagonalexam/adapter/out/UserMapper.java
+++ b/mybatis-hexagonal-exam/src/main/java/org/rookedsysc/mybatishexagonalexam/adapter/out/UserMapper.java
@@ -5,7 +5,7 @@ import org.rookedsysc.mybatishexagonalexam.adapter.out.entity.UserEntity;
 
 @Mapper
 public interface UserMapper {
-    int save(UserEntity userEntity);
+    long save(UserEntity userEntity);
 
     UserEntity findByEmail(String email);
 }

--- a/mybatis-hexagonal-exam/src/main/java/org/rookedsysc/mybatishexagonalexam/adapter/out/entity/UserEntity.java
+++ b/mybatis-hexagonal-exam/src/main/java/org/rookedsysc/mybatishexagonalexam/adapter/out/entity/UserEntity.java
@@ -2,9 +2,11 @@ package org.rookedsysc.mybatishexagonalexam.adapter.out.entity;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 public class UserEntity {
+    @Setter
     private Long id;
     private String email;
     private String password;

--- a/mybatis-hexagonal-exam/src/main/java/org/rookedsysc/mybatishexagonalexam/application/PostUploadService.java
+++ b/mybatis-hexagonal-exam/src/main/java/org/rookedsysc/mybatishexagonalexam/application/PostUploadService.java
@@ -16,7 +16,7 @@ public class PostUploadService implements PostUploadUsecase {
 
     @Override
     public long upload(PostCommand command) {
-        PostEntity entity = PostEntityConverter.toEntity(command)
+        PostEntity entity = PostEntityConverter.toEntity(command);
         return postUploadPort.upload(entity);
     }
 }


### PR DESCRIPTION
## Related Issue

Related to : #15 

## Overview

- User setId 
- Mapper save() 메서드 return type int -> long

## Result
