### PR TITLE
feat(kafka-az): 게시글 WebFlux CRUD API 추가

### DIFF
--- a/kafka-az/kafka-az/build.gradle.kts
+++ b/kafka-az/kafka-az/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     kotlin("plugin.spring") version "2.3.21"
     id("org.springframework.boot") version "4.1.0"
     id("io.spring.dependency-management") version "1.1.7"
-    kotlin("plugin.jpa") version "2.3.21"
 }
 
 group = "com.roky"
@@ -21,30 +20,33 @@ repositories {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
     implementation("tools.jackson.module:jackson-module-kotlin")
-    runtimeOnly("org.postgresql:postgresql")
-    testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
+    implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:3.0.3")
+    developmentOnly("org.springframework.boot:spring-boot-docker-compose")
+    runtimeOnly("org.postgresql:r2dbc-postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-webflux-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
+    testImplementation("org.testcontainers:postgresql")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("org.testcontainers:testcontainers-bom:1.21.4")
+    }
 }
 
 kotlin {
     compilerOptions {
         freeCompilerArgs.addAll("-Xjsr305=strict", "-Xannotation-default-target=param-property")
     }
-}
-
-allOpen {
-    annotation("jakarta.persistence.Entity")
-    annotation("jakarta.persistence.MappedSuperclass")
-    annotation("jakarta.persistence.Embeddable")
 }
 
 tasks.withType<Test> {

--- a/kafka-az/kafka-az/compose.yaml
+++ b/kafka-az/kafka-az/compose.yaml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: kafka-az-postgres
+    environment:
+      POSTGRES_DB: kafka_az
+      POSTGRES_USER: kafka_az
+      POSTGRES_PASSWORD: kafka_az
+    ports:
+      - "5432:5432"
+    volumes:
+      - kafka_az_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U kafka_az -d kafka_az"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  kafka_az_postgres_data:

--- a/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/config/OpenApiConfig.kt
+++ b/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/config/OpenApiConfig.kt
@@ -1,0 +1,21 @@
+package com.roky.kafkaaz.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+
+    @Bean
+    fun openApi(): OpenAPI {
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("Kafka AZ API")
+                    .description("Post CRUD API")
+                    .version("v1")
+            )
+    }
+}

--- a/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/Post.kt
+++ b/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/Post.kt
@@ -1,0 +1,25 @@
+package com.roky.kafkaaz.post
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+
+@Table(name = "posts")
+data class Post(
+    @Id
+    val id: Long? = null,
+
+    @Column("title")
+    val title: String,
+
+    @Column("content")
+    val content: String
+) {
+
+    fun update(title: String, content: String): Post {
+        return copy(
+            title = title,
+            content = content
+        )
+    }
+}

--- a/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/PostController.kt
+++ b/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/PostController.kt
@@ -1,0 +1,60 @@
+package com.roky.kafkaaz.post
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+@RestController
+@RequestMapping("/api/v1/posts")
+@Tag(name = "Post API", description = "게시물 CRUD API")
+class PostController(
+    private val postService: PostService
+) {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "게시물 생성")
+    fun create(@Valid @RequestBody request: PostCreateRequest): Mono<PostResponse> {
+        return postService.create(request)
+    }
+
+    @GetMapping
+    @Operation(summary = "게시물 목록 조회")
+    fun findAll(): Flux<PostResponse> {
+        return postService.findAll()
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "게시물 단건 조회")
+    fun findById(@PathVariable id: Long): Mono<PostResponse> {
+        return postService.findById(id)
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "게시물 수정")
+    fun update(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: PostUpdateRequest
+    ): Mono<PostResponse> {
+        return postService.update(id, request)
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "게시물 삭제")
+    fun delete(@PathVariable id: Long): Mono<Void> {
+        return postService.delete(id)
+    }
+}

--- a/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/PostRepository.kt
+++ b/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/PostRepository.kt
@@ -1,0 +1,9 @@
+package com.roky.kafkaaz.post
+
+import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Flux
+
+interface PostRepository : ReactiveCrudRepository<Post, Long> {
+
+    fun findAllByOrderByIdDesc(): Flux<Post>
+}

--- a/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/PostRequest.kt
+++ b/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/PostRequest.kt
@@ -1,0 +1,29 @@
+package com.roky.kafkaaz.post
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class PostCreateRequest(
+    @field:NotBlank(message = "제목은 비어있을 수 없습니다.")
+    @field:Size(max = 100, message = "제목은 100자를 초과할 수 없습니다.")
+    @Schema(description = "게시물 제목", example = "First post", maxLength = 100)
+    val title: String,
+
+    @field:NotBlank(message = "본문은 비어있을 수 없습니다.")
+    @field:Size(max = 5000, message = "본문은 5000자를 초과할 수 없습니다.")
+    @Schema(description = "게시물 본문", example = "Hello Kafka AZ", maxLength = 5000)
+    val content: String
+)
+
+data class PostUpdateRequest(
+    @field:NotBlank(message = "제목은 비어있을 수 없습니다.")
+    @field:Size(max = 100, message = "제목은 100자를 초과할 수 없습니다.")
+    @Schema(description = "게시물 제목", example = "Updated post", maxLength = 100)
+    val title: String,
+
+    @field:NotBlank(message = "본문은 비어있을 수 없습니다.")
+    @field:Size(max = 5000, message = "본문은 5000자를 초과할 수 없습니다.")
+    @Schema(description = "게시물 본문", example = "Updated content", maxLength = 5000)
+    val content: String
+)

--- a/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/PostResponse.kt
+++ b/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/PostResponse.kt
@@ -1,0 +1,24 @@
+package com.roky.kafkaaz.post
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class PostResponse(
+    @Schema(description = "게시물 ID", example = "1")
+    val id: Long,
+
+    @Schema(description = "게시물 제목", example = "First post")
+    val title: String,
+
+    @Schema(description = "게시물 본문", example = "Hello Kafka AZ")
+    val content: String
+) {
+    companion object {
+        fun from(post: Post): PostResponse {
+            return PostResponse(
+                id = post.id ?: throw IllegalStateException("Post id must not be null"),
+                title = post.title,
+                content = post.content
+            )
+        }
+    }
+}

--- a/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/PostService.kt
+++ b/kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/PostService.kt
@@ -1,0 +1,59 @@
+package com.roky.kafkaaz.post
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+@Service
+class PostService(
+    private val postRepository: PostRepository
+) {
+
+    fun create(request: PostCreateRequest): Mono<PostResponse> {
+        val post = Post(
+            title = request.title,
+            content = request.content
+        )
+
+        return postRepository.save(post)
+            .map(PostResponse::from)
+    }
+
+    fun findAll(): Flux<PostResponse> {
+        return postRepository.findAllByOrderByIdDesc()
+            .map(PostResponse::from)
+    }
+
+    fun findById(id: Long): Mono<PostResponse> {
+        return getPost(id)
+            .map(PostResponse::from)
+    }
+
+    fun update(id: Long, request: PostUpdateRequest): Mono<PostResponse> {
+        return getPost(id)
+            .map {
+                it.update(
+                    title = request.title,
+                    content = request.content
+                )
+            }
+            .flatMap(postRepository::save)
+            .map(PostResponse::from)
+    }
+
+    fun delete(id: Long): Mono<Void> {
+        return getPost(id)
+            .flatMap(postRepository::delete)
+    }
+
+    private fun getPost(id: Long): Mono<Post> {
+        return postRepository.findById(id)
+            .switchIfEmpty(postNotFound(id))
+    }
+
+    private fun postNotFound(id: Long): Mono<Post> {
+        return Mono.error(ResponseStatusException(HttpStatus.NOT_FOUND, "Post not found: $id"))
+    }
+}

--- a/kafka-az/kafka-az/src/main/resources/application.yaml
+++ b/kafka-az/kafka-az/src/main/resources/application.yaml
@@ -1,3 +1,20 @@
 spring:
   application:
     name: kafka-az
+  r2dbc:
+    url: ${SPRING_R2DBC_URL:r2dbc:postgresql://localhost:5432/kafka_az}
+    username: ${SPRING_R2DBC_USERNAME:kafka_az}
+    password: ${SPRING_R2DBC_PASSWORD:kafka_az}
+  docker:
+    compose:
+      file: compose.yaml
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema.sql
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html

--- a/kafka-az/kafka-az/src/main/resources/application.yaml
+++ b/kafka-az/kafka-az/src/main/resources/application.yaml
@@ -2,9 +2,9 @@ spring:
   application:
     name: kafka-az
   r2dbc:
-    url: ${SPRING_R2DBC_URL:r2dbc:postgresql://localhost:5432/kafka_az}
-    username: ${SPRING_R2DBC_USERNAME:kafka_az}
-    password: ${SPRING_R2DBC_PASSWORD:kafka_az}
+    url: r2dbc:postgresql://localhost:5432/kafka_az
+    username: kafka_az
+    password: kafka_az
   docker:
     compose:
       file: compose.yaml

--- a/kafka-az/kafka-az/src/main/resources/schema.sql
+++ b/kafka-az/kafka-az/src/main/resources/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS posts (
+    id BIGSERIAL PRIMARY KEY,
+    title VARCHAR(100) NOT NULL,
+    content TEXT NOT NULL
+);

--- a/kafka-az/kafka-az/src/test/kotlin/com/roky/kafkaaz/KafkaAzApplicationTests.kt
+++ b/kafka-az/kafka-az/src/test/kotlin/com/roky/kafkaaz/KafkaAzApplicationTests.kt
@@ -1,10 +1,11 @@
 package com.roky.kafkaaz
 
+import com.roky.kafkaaz.support.PostgreSQLTestContainerSupport
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
-class KafkaAzApplicationTests {
+class KafkaAzApplicationTests : PostgreSQLTestContainerSupport() {
 
     @Test
     fun contextLoads() {

--- a/kafka-az/kafka-az/src/test/kotlin/com/roky/kafkaaz/post/PostControllerIntegrationTests.kt
+++ b/kafka-az/kafka-az/src/test/kotlin/com/roky/kafkaaz/post/PostControllerIntegrationTests.kt
@@ -1,0 +1,115 @@
+package com.roky.kafkaaz.post
+
+import com.roky.kafkaaz.support.PostgreSQLTestContainerSupport
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+class PostControllerIntegrationTests @Autowired constructor(
+    private val webTestClient: WebTestClient,
+    private val postRepository: PostRepository
+) : PostgreSQLTestContainerSupport() {
+
+    @BeforeEach
+    fun setUp() {
+        postRepository.deleteAll().block()
+    }
+
+    @Test
+    fun `creates reads updates and deletes a post`() {
+        val created = webTestClient.post()
+            .uri("/api/v1/posts")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                mapOf(
+                    "title" to "First post",
+                    "content" to "Hello Kafka AZ"
+                )
+            )
+            .exchange()
+            .expectStatus().isCreated
+            .expectBody(Map::class.java)
+            .returnResult()
+            .responseBody
+
+        assertNotNull(created)
+        val postId = (created["id"] as Number).toLong()
+        assertEquals("First post", created["title"])
+        assertEquals("Hello Kafka AZ", created["content"])
+
+        webTestClient.get()
+            .uri("/api/v1/posts")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$[0].id").isEqualTo(postId)
+            .jsonPath("$[0].title").isEqualTo("First post")
+            .jsonPath("$[0].content").isEqualTo("Hello Kafka AZ")
+
+        webTestClient.get()
+            .uri("/api/v1/posts/{id}", postId)
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.id").isEqualTo(postId)
+            .jsonPath("$.title").isEqualTo("First post")
+            .jsonPath("$.content").isEqualTo("Hello Kafka AZ")
+
+        webTestClient.put()
+            .uri("/api/v1/posts/{id}", postId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                mapOf(
+                    "title" to "Updated post",
+                    "content" to "Updated content"
+                )
+            )
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.id").isEqualTo(postId)
+            .jsonPath("$.title").isEqualTo("Updated post")
+            .jsonPath("$.content").isEqualTo("Updated content")
+
+        webTestClient.delete()
+            .uri("/api/v1/posts/{id}", postId)
+            .exchange()
+            .expectStatus().isNoContent
+
+        webTestClient.get()
+            .uri("/api/v1/posts/{id}", postId)
+            .exchange()
+            .expectStatus().isNotFound
+    }
+
+    @Test
+    fun `exposes swagger documentation for post api`() {
+        webTestClient.get()
+            .uri("/v3/api-docs")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.paths['/api/v1/posts']").exists()
+            .jsonPath("$.paths['/api/v1/posts/{id}']").exists()
+
+        val swaggerUiStatus = webTestClient.get()
+            .uri("/swagger-ui.html")
+            .exchange()
+            .returnResult(Void::class.java)
+            .status
+
+        assertTrue(
+            swaggerUiStatus.is2xxSuccessful || swaggerUiStatus.is3xxRedirection,
+            "Swagger UI should be reachable but was $swaggerUiStatus"
+        )
+    }
+}

--- a/kafka-az/kafka-az/src/test/kotlin/com/roky/kafkaaz/support/PostgreSQLTestContainerSupport.kt
+++ b/kafka-az/kafka-az/src/test/kotlin/com/roky/kafkaaz/support/PostgreSQLTestContainerSupport.kt
@@ -1,0 +1,32 @@
+package com.roky.kafkaaz.support
+
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+
+abstract class PostgreSQLTestContainerSupport {
+
+    companion object {
+        private const val DATABASE_NAME = "kafka_az_test"
+
+        private val postgres = PostgreSQLContainer(DockerImageName.parse("postgres:17-alpine"))
+            .withDatabaseName(DATABASE_NAME)
+            .withUsername("kafka_az")
+            .withPassword("kafka_az")
+
+        init {
+            postgres.start()
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerPostgreSQLProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.r2dbc.url") {
+                "r2dbc:postgresql://${postgres.host}:${postgres.firstMappedPort}/$DATABASE_NAME"
+            }
+            registry.add("spring.r2dbc.username", postgres::getUsername)
+            registry.add("spring.r2dbc.password", postgres::getPassword)
+        }
+    }
+}

--- a/kafka-az/kafka-az/src/test/resources/application.yaml
+++ b/kafka-az/kafka-az/src/test/resources/application.yaml
@@ -1,0 +1,8 @@
+spring:
+  docker:
+    compose:
+      enabled: false
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema.sql


### PR DESCRIPTION
## 어떤 작업인가요?
- Kafka AZ 애플리케이션에 WebFlux 기반 게시글 CRUD API와 PostgreSQL 저장소 연동을 추가합니다.

## 어떻게 해결했나요?
**게시글 CRUD API 추가**
- `/api/v1/posts` 생성, 목록 조회, 단건 조회, 수정, 삭제 엔드포인트를 추가했습니다.
- 요청 검증 DTO와 응답 DTO를 분리하고, 서비스 계층에서 404 응답을 처리하도록 구성했습니다.

**R2DBC PostgreSQL 전환**
- JPA 의존성을 제거하고 R2DBC PostgreSQL, validation, springdoc 의존성을 추가했습니다.
- `posts` 테이블 스키마 초기화와 로컬 PostgreSQL Docker Compose 구성을 추가했습니다.
- 애플리케이션 기본 R2DBC 연결값을 compose의 로컬 PostgreSQL 기본값과 동일하게 명시했습니다.

**API 문서와 통합 테스트 추가**
- OpenAPI 설정과 Swagger UI 경로를 추가했습니다.
- Testcontainers 기반 PostgreSQL 테스트 환경에서 게시글 CRUD와 OpenAPI 노출을 검증하는 통합 테스트를 추가했습니다.

## 중요한 변경 사항은 무엇인가요?
### 게시글 API

**WebFlux/R2DBC 기반 CRUD 구현**
- **변경 이유**: 블로킹 JPA 대신 reactive stack과 맞는 게시글 저장/조회 흐름을 제공하기 위해서입니다.
- **수정 파일**: `kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/post/*`

**PostgreSQL 실행 및 스키마 초기화 구성**
- **변경 이유**: 로컬 실행과 애플리케이션 시작 시 동일한 `posts` 테이블 구조와 DB 연결 기본값을 사용할 수 있게 하기 위해서입니다.
- **수정 파일**: `kafka-az/kafka-az/compose.yaml`, `kafka-az/kafka-az/src/main/resources/application.yaml`, `kafka-az/kafka-az/src/main/resources/schema.sql`

### 문서와 테스트

**OpenAPI 문서화 추가**
- **변경 이유**: 게시글 API 경로와 요청/응답 모델을 Swagger UI와 OpenAPI 문서로 확인할 수 있게 하기 위해서입니다.
- **수정 파일**: `kafka-az/kafka-az/src/main/kotlin/com/roky/kafkaaz/config/OpenApiConfig.kt`, `kafka-az/kafka-az/build.gradle.kts`

**PostgreSQL 통합 테스트 추가**
- **변경 이유**: 실제 PostgreSQL 호환 환경에서 CRUD 동작과 API 문서 노출을 검증하기 위해서입니다.
- **수정 파일**: `kafka-az/kafka-az/src/test/kotlin/com/roky/kafkaaz/post/PostControllerIntegrationTests.kt`, `kafka-az/kafka-az/src/test/kotlin/com/roky/kafkaaz/support/PostgreSQLTestContainerSupport.kt`, `kafka-az/kafka-az/src/test/resources/application.yaml`

Co-Authored-By: Codex <codex@openai.com>