### PR TITLE
feat(kafka-az): Kafka 로컬 개발 환경 추가

### DIFF
--- a/kafka-az/build.gradle.kts
+++ b/kafka-az/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
+    implementation("org.springframework.kafka:spring-kafka")
     implementation("tools.jackson.module:jackson-module-kotlin")
     implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:3.0.3")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")

--- a/kafka-az/compose.yaml
+++ b/kafka-az/compose.yaml
@@ -16,5 +16,54 @@ services:
       timeout: 5s
       retries: 5
 
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.8.0
+    container_name: kafka-az-zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+    volumes:
+      - kafka_az_zookeeper_data:/var/lib/zookeeper/data
+      - kafka_az_zookeeper_log:/var/lib/zookeeper/log
+
+  kafka:
+    image: confluentinc/cp-kafka:7.8.0
+    container_name: kafka-az-kafka
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    ports:
+      - "9092:9092"
+    volumes:
+      - kafka_az_kafka_data:/var/lib/kafka/data
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:v0.7.2
+    container_name: kafka-az-kafka-ui
+    depends_on:
+      - kafka
+    environment:
+      KAFKA_CLUSTERS_0_NAME: kafka-az-local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+    ports:
+      - "8081:8080"
+
 volumes:
   kafka_az_postgres_data:
+  kafka_az_zookeeper_data:
+  kafka_az_zookeeper_log:
+  kafka_az_kafka_data:

--- a/kafka-az/src/main/resources/application.yaml
+++ b/kafka-az/src/main/resources/application.yaml
@@ -5,6 +5,16 @@ spring:
     url: r2dbc:postgresql://localhost:5432/kafka_az
     username: kafka_az
     password: kafka_az
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: kafka-az
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
   docker:
     compose:
       file: compose.yaml


### PR DESCRIPTION
## 어떤 작업인가요?
- `kafka-az` 프로젝트에서 로컬 Kafka 개발 환경을 사용할 수 있도록 Spring Kafka 설정과 Docker Compose 서비스를 추가합니다.

## 어떻게 해결했나요?
**Kafka 의존성 추가**
- Spring Kafka 의존성을 추가해 애플리케이션에서 Kafka producer/consumer 설정을 사용할 수 있게 했습니다.

**로컬 Kafka 인프라 구성**
- Docker Compose에 ZooKeeper, Kafka, Kafka UI 서비스를 추가했습니다.
- Kafka 데이터와 ZooKeeper 데이터/로그를 보존할 볼륨을 구성했습니다.

**애플리케이션 Kafka 기본 설정 추가**
- `localhost:9092` bootstrap server를 사용하도록 설정했습니다.
- 문자열 기반 producer/consumer serializer와 deserializer를 기본값으로 구성했습니다.

## 중요한 변경 사항은 무엇인가요?
### Kafka 로컬 개발 환경

**Docker Compose 기반 Kafka 스택 추가**
- **변경 이유**: 로컬에서 Kafka와 Kafka UI를 함께 실행해 메시징 기능 개발 기반을 마련하기 위해서입니다.
- **수정 파일**: `kafka-az/compose.yaml`

**Spring Kafka 설정 추가**
- **변경 이유**: 애플리케이션이 Kafka broker에 연결하고 문자열 메시지를 송수신할 수 있도록 기본 설정을 제공하기 위해서입니다.
- **수정 파일**: `kafka-az/build.gradle.kts`, `kafka-az/src/main/resources/application.yaml`

Co-Authored-By: OpenAI Codex <codex@openai.com>
