### PR TITLE
feat(redis): logical database PoC 추가

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,160 @@
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
+project_name: "feat-redis-database"
+
+# list of languages for which language servers are started (LSP backend only); choose from:
+#   ada                 al                  angular             ansible             bash
+#   bsl                 clojure             cpp                 cpp_ccls            crystal
+#   csharp              csharp_omnisharp    cue                 dart                elixir
+#   elm                 erlang              fortran             fsharp              gdscript
+#   go                  groovy              haskell             haxe                hlsl
+#   html                java                json                julia               kotlin
+#   latex               lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        php_phpantom        powershell
+#   python              python_jedi         python_pyrefly      python_ty           r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   scss                solidity            svelte              swift               systemverilog
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- kotlin
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
+ls_specific_settings: {}
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- "."
+
+# list of additional workspace folder paths for cross-package reference support.
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+ls_additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/redis-database/README.md
+++ b/redis-database/README.md
@@ -4,14 +4,14 @@ Redis의 `DB 0`, `DB 1`은 독립 서버가 아니라 하나의 Redis 인스턴�
 
 ## 가장 빠르게 확인하기
 
-Python 3, Docker와 Docker Compose가 필요합니다. 검증 코드는 Python 표준 라이브러리만 사용하므로 별도 패키지를 설치하지 않습니다.
+`uv`, Docker와 Docker Compose가 필요합니다. 검증 코드는 Python 표준 라이브러리만 사용하므로 별도 패키지를 설치하지 않습니다.
 
 ```bash
 cd redis-database
-uv run python verify.py
+uv run verify.py
 ```
 
-`uv`가 없다면 `python3 verify.py`로 실행해도 됩니다. Python 코드는 Redis 명령별 검증 함수를 위에서 아래로 호출하므로 README의 학습 순서와 동일하게 읽을 수 있습니다.
+`uv`는 `verify.py`의 인라인 메타데이터를 읽어 Python 3.10 이상을 선택합니다. Python 코드는 Redis 명령별 검증 함수를 위에서 아래로 호출하므로 README의 학습 순서와 동일하게 읽을 수 있습니다.
 
 성공하면 다음과 같은 결과가 출력됩니다.
 

--- a/redis-database/README.md
+++ b/redis-database/README.md
@@ -1,0 +1,135 @@
+# Redis logical database PoC
+
+Redis의 `DB 0`, `DB 1`은 독립 서버가 아니라 하나의 Redis 인스턴스 안에 있는 키 네임스페이스입니다. 이 PoC는 같은 키 이름의 분리, DB 단위 명령, 데이터셋 교환과 서버 설정 공유를 직접 확인합니다.
+
+## 가장 빠르게 확인하기
+
+Python 3, Docker와 Docker Compose가 필요합니다. 검증 코드는 Python 표준 라이브러리만 사용하므로 별도 패키지를 설치하지 않습니다.
+
+```bash
+cd redis-database
+uv run python verify.py
+```
+
+`uv`가 없다면 `python3 verify.py`로 실행해도 됩니다. Python 코드는 Redis 명령별 검증 함수를 위에서 아래로 호출하므로 README의 학습 순서와 동일하게 읽을 수 있습니다.
+
+성공하면 다음과 같은 결과가 출력됩니다.
+
+```text
+Redis 컨테이너를 시작합니다.
+PASS: 같은 키 이름을 DB 0에서 독립적으로 조회
+PASS: 같은 키 이름을 DB 1에서 독립적으로 조회
+PASS: FLUSHDB가 다른 DB의 키를 유지
+PASS: FLUSHDB가 선택한 DB만 비움
+PASS: SWAPDB가 DB 0의 데이터셋을 교환
+PASS: SWAPDB가 DB 1의 데이터셋을 교환
+PASS: DB 1에서 바꾼 eviction 정책을 DB 0도 공유
+PASS: eviction 정책은 logical DB별 설정이 아님
+Redis logical database PoC 검증을 완료했습니다.
+```
+
+`verify.py`는 이 PoC 전용 Redis 컨테이너에 `FLUSHALL`을 실행해 매번 같은 초기 상태에서 검증합니다. 외부 Redis 주소에는 연결하지 않습니다.
+
+## 직접 따라 해보기
+
+Redis를 시작합니다.
+
+```bash
+docker compose up -d --wait
+```
+
+### 같은 키 이름을 분리한다
+
+`-n`은 연결할 logical database 번호를 선택하는 `redis-cli` 옵션입니다. 내부적으로는 연결에 `SELECT` 명령을 적용합니다.
+
+```bash
+docker compose exec redis redis-cli -n 0 SET user:1 db-0-user
+docker compose exec redis redis-cli -n 1 SET user:1 db-1-user
+
+docker compose exec redis redis-cli -n 0 GET user:1
+docker compose exec redis redis-cli -n 1 GET user:1
+```
+
+각 DB에서 같은 `user:1`을 사용했지만 결과는 각각 `db-0-user`, `db-1-user`입니다. 이것이 logical database의 핵심 역할인 네임스페이스 분리입니다.
+
+새 연결은 항상 DB 0에서 시작하고, 선택한 DB 번호는 연결 상태에 속합니다. 연결이 끊겼다가 다시 만들어지면 클라이언트가 DB를 다시 선택해야 합니다.
+
+> Redis 공식 문서: [`SELECT`](https://redis.io/docs/latest/commands/select/)
+
+### 선택한 DB만 조회하거나 비운다
+
+`DBSIZE`, `SCAN`, `RANDOMKEY`, `FLUSHDB` 같은 명령은 현재 연결이 선택한 DB를 기준으로 동작합니다.
+
+```bash
+docker compose exec redis redis-cli -n 0 DBSIZE
+docker compose exec redis redis-cli -n 1 DBSIZE
+
+docker compose exec redis redis-cli -n 1 FLUSHDB
+docker compose exec redis redis-cli -n 0 GET user:1
+docker compose exec redis redis-cli -n 1 GET user:1
+```
+
+DB 1을 비워도 DB 0의 `user:1`은 남아 있습니다. 따라서 같은 애플리케이션 안에서 재생성 가능한 키 묶음을 통째로 비우는 용도로 사용할 수 있습니다.
+
+### 두 DB의 데이터셋을 교환한다
+
+`SWAPDB`는 두 logical database의 데이터셋을 교환합니다.
+
+```bash
+docker compose exec redis redis-cli -n 0 SET active-dataset blue
+docker compose exec redis redis-cli -n 1 SET active-dataset green
+docker compose exec redis redis-cli SWAPDB 0 1
+
+docker compose exec redis redis-cli -n 0 GET active-dataset
+docker compose exec redis redis-cli -n 1 GET active-dataset
+```
+
+결과는 DB 0이 `green`, DB 1이 `blue`입니다. 새 데이터셋을 다른 DB에서 준비한 뒤 교환하는 실험에 활용할 수 있습니다.
+
+> Redis 공식 문서: [`SWAPDB`](https://redis.io/docs/latest/commands/swapdb/)
+
+### 메모리와 eviction 정책은 공유한다
+
+다음 명령은 DB 1 연결에서 eviction 정책을 바꾼 뒤 DB 0과 DB 1에서 각각 조회합니다.
+
+```bash
+docker compose exec redis redis-cli -n 1 CONFIG SET maxmemory-policy allkeys-lru
+docker compose exec redis redis-cli -n 0 CONFIG GET maxmemory-policy
+docker compose exec redis redis-cli -n 1 CONFIG GET maxmemory-policy
+```
+
+두 DB 모두 `allkeys-lru`를 반환합니다. `maxmemory`와 `maxmemory-policy`는 logical database 설정이 아니라 Redis 인스턴스 설정이기 때문입니다. 실험을 마친 뒤 기본 정책으로 되돌립니다.
+
+```bash
+docker compose exec redis redis-cli CONFIG SET maxmemory-policy noeviction
+```
+
+> Redis 공식 문서: [Key eviction](https://redis.io/docs/latest/develop/reference/eviction/)
+
+## 무엇이 분리되고 무엇이 공유되는가
+
+| 항목 | DB별 분리 여부 | 설명 |
+| --- | --- | --- |
+| 키 이름 공간 | 분리 | DB마다 같은 이름의 키를 저장할 수 있습니다. |
+| `DBSIZE`, `SCAN`, `FLUSHDB` | 분리 | 현재 선택한 DB를 대상으로 실행됩니다. |
+| 메모리 한도 | 공유 | `maxmemory`는 인스턴스 전체에 적용됩니다. |
+| eviction 정책 | 공유 | `maxmemory-policy`는 인스턴스당 하나입니다. |
+| CPU와 장애 영향 | 공유 | 하나의 Redis 프로세스를 사용합니다. |
+| RDB/AOF와 복제 | 공유 | 모든 logical DB가 함께 저장되고 복제됩니다. |
+| Pub/Sub | 공유 | 채널은 logical DB 네임스페이스에 속하지 않습니다. |
+
+따라서 logical database는 같은 애플리케이션 안에서 키 묶음을 편리하게 관리할 때만 적합합니다. 서로 무관한 애플리케이션, 메모리 quota, 서로 다른 eviction 정책 또는 장애 격리가 필요하면 Redis 인스턴스를 분리해야 합니다.
+
+Redis Cluster는 DB 0만 지원합니다. Cluster 전환 가능성이 있다면 logical database 대신 `cache:`, `lock:`, `session:` 같은 key prefix를 사용하는 편이 이식성이 좋습니다.
+
+> Redis 공식 문서: [`SELECT`](https://redis.io/docs/latest/commands/select/), [Redis Pub/Sub](https://redis.io/docs/latest/develop/pubsub/)
+
+Redis Software나 Redis Cloud에서 독립 리소스를 뜻하는 “database”는 이 PoC의 Redis Open Source logical database와 다른 개념입니다.
+
+## 종료하기
+
+이 PoC는 볼륨을 만들지 않습니다. 다음 명령으로 컨테이너와 네트워크를 제거할 수 있습니다.
+
+```bash
+docker compose down
+```

--- a/redis-database/compose.yaml
+++ b/redis-database/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  redis:
+    image: redis:7.4-alpine
+    healthcheck:
+      # 로컬 PoC 시작 실패를 10초 안에 드러내기 위한 짧은 readiness 간격입니다.
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 1s
+      retries: 10

--- a/redis-database/verify.py
+++ b/redis-database/verify.py
@@ -1,0 +1,143 @@
+import subprocess
+from pathlib import Path
+
+PROJECT_DIRECTORY = Path(__file__).resolve().parent
+COMPOSE_FILE = PROJECT_DIRECTORY / "compose.yaml"
+
+
+def run_compose(*arguments: str) -> str:
+    command = [
+        "docker",
+        "compose",
+        "--project-directory",
+        str(PROJECT_DIRECTORY),
+        "-f",
+        str(COMPOSE_FILE),
+        *arguments,
+    ]
+    completed_process = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed_process.stdout.strip()
+
+
+def run_redis(*arguments: str, database: int | None = None) -> str:
+    command = ["exec", "-T", "redis", "redis-cli", "--raw"]
+    if database is not None:
+        command.extend(["-n", str(database)])
+
+    return run_compose(*command, *arguments)
+
+
+def assert_equal(expected: str, actual: str, description: str) -> None:
+    if actual != expected:
+        raise AssertionError(
+            f"FAIL: {description} (expected={expected}, actual={actual})"
+        )
+
+    print(f"PASS: {description}")
+
+
+def verify_same_key_is_isolated_by_database() -> None:
+    run_redis("SET", "example:key", "db-0", database=0)
+    run_redis("SET", "example:key", "db-1", database=1)
+
+    assert_equal(
+        "db-0",
+        run_redis("GET", "example:key", database=0),
+        "같은 키 이름을 DB 0에서 독립적으로 조회",
+    )
+    assert_equal(
+        "db-1",
+        run_redis("GET", "example:key", database=1),
+        "같은 키 이름을 DB 1에서 독립적으로 조회",
+    )
+
+
+def verify_flushdb_only_clears_selected_database() -> None:
+    run_redis("SET", "flush:key", "db-0", database=0)
+    run_redis("SET", "flush:key", "db-1", database=1)
+    run_redis("FLUSHDB", database=1)
+
+    assert_equal(
+        "db-0",
+        run_redis("GET", "flush:key", database=0),
+        "FLUSHDB가 다른 DB의 키를 유지",
+    )
+    assert_equal(
+        "",
+        run_redis("GET", "flush:key", database=1),
+        "FLUSHDB가 선택한 DB만 비움",
+    )
+
+
+def verify_swapdb_exchanges_datasets() -> None:
+    run_redis("SET", "active-dataset", "blue", database=0)
+    run_redis("SET", "active-dataset", "green", database=1)
+    run_redis("SWAPDB", "0", "1")
+
+    assert_equal(
+        "green",
+        run_redis("GET", "active-dataset", database=0),
+        "SWAPDB가 DB 0의 데이터셋을 교환",
+    )
+    assert_equal(
+        "blue",
+        run_redis("GET", "active-dataset", database=1),
+        "SWAPDB가 DB 1의 데이터셋을 교환",
+    )
+
+
+def get_eviction_policy(database: int) -> str:
+    config_response = run_redis(
+        "CONFIG",
+        "GET",
+        "maxmemory-policy",
+        database=database,
+    )
+    return config_response.splitlines()[-1]
+
+
+def verify_eviction_policy_is_shared() -> None:
+    original_policy = get_eviction_policy(database=0)
+
+    try:
+        run_redis(
+            "CONFIG",
+            "SET",
+            "maxmemory-policy",
+            "allkeys-lru",
+            database=1,
+        )
+        assert_equal(
+            "allkeys-lru",
+            get_eviction_policy(database=0),
+            "DB 1에서 바꾼 eviction 정책을 DB 0도 공유",
+        )
+        assert_equal(
+            "allkeys-lru",
+            get_eviction_policy(database=1),
+            "eviction 정책은 logical DB별 설정이 아님",
+        )
+    finally:
+        run_redis("CONFIG", "SET", "maxmemory-policy", original_policy)
+
+
+def main() -> None:
+    print("Redis 컨테이너를 시작합니다.")
+    run_compose("up", "-d", "--wait")
+    run_redis("FLUSHALL")
+
+    verify_same_key_is_isolated_by_database()
+    verify_flushdb_only_clears_selected_database()
+    verify_swapdb_exchanges_datasets()
+    verify_eviction_policy_is_shared()
+
+    print("Redis logical database PoC 검증을 완료했습니다.")
+
+
+if __name__ == "__main__":
+    main()

--- a/redis-database/verify.py
+++ b/redis-database/verify.py
@@ -1,3 +1,8 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+
 import subprocess
 from pathlib import Path
 


### PR DESCRIPTION
## 어떤 작업인가요?
- Redis logical database가 키 네임스페이스를 분리하지만 메모리와 eviction 정책은 공유한다는 점을 직접 실행해 확인하는 PoC를 추가합니다.

## 어떻게 해결했나요?
**독립 Redis 실행 환경**
- Redis 7.4 컨테이너와 readiness healthcheck를 Compose로 구성했습니다.

**Python 검증 시나리오**
- DB별 동일 키 분리, `FLUSHDB`, `SWAPDB`, `maxmemory-policy` 공유를 8개 assertion으로 검증합니다.
- eviction 정책은 검증 후 원래 값으로 복원합니다.

**학습 문서**
- README만 따라 실행하고 직접 명령을 재현할 수 있도록 개념과 절차를 정리했습니다.

## 중요한 변경 사항은 무엇인가요?
### Redis logical database 실행형 예제

**네임스페이스와 DB 단위 명령 검증**
- **변경 이유**: logical database가 무엇을 분리하는지 실행 결과로 확인하기 위함입니다.
- **수정 파일**: `redis-database/verify.py`

**인스턴스 전역 설정 공유 검증**
- **변경 이유**: database별 메모리 한도나 eviction 정책을 설정할 수 없음을 명확히 보여주기 위함입니다.
- **수정 파일**: `redis-database/verify.py`, `redis-database/README.md`

**재현 가능한 로컬 환경**
- **변경 이유**: 외부 Redis에 영향을 주지 않고 동일한 결과를 반복 확인하기 위함입니다.
- **수정 파일**: `redis-database/compose.yaml`

Co-Authored-By: Codex <codex@openai.com>